### PR TITLE
fix(gzip): Interpret redirects properly by using shell environment in docker executions.

### DIFF
--- a/assets/gzip/main.py
+++ b/assets/gzip/main.py
@@ -37,7 +37,7 @@ class gzip_bench(Benchmark):
         """
         Ingests the dataset at self.datasets_path
         """
-        self.docker_execute(f"gzip -c {self.datasets_path} > {GZIP_FILE_PATH} ")
+        self.docker_execute(f"gzip -c {self.datasets_path} > {GZIP_FILE_PATH} ", shell=True)
     
     def search(self, query):
         """
@@ -45,7 +45,7 @@ class gzip_bench(Benchmark):
         """
         assert query == "notasearch"
 
-        self.docker_execute(f"gunzip -c {GZIP_FILE_PATH} > {DECOMPRESSED_FILE_PATH}")
+        self.docker_execute(f"gunzip -c {GZIP_FILE_PATH} > {DECOMPRESSED_FILE_PATH}", shell=True)
         return 0
     def bench_search(self, cold=True):
         if not cold:
@@ -53,7 +53,7 @@ class gzip_bench(Benchmark):
             return
 
         self.bench_start(ingest=False)
-        self.docker_execute(f"gunzip -c {GZIP_FILE_PATH} > {DECOMPRESSED_FILE_PATH}")
+        self.docker_execute(f"gunzip -c {GZIP_FILE_PATH} > {DECOMPRESSED_FILE_PATH}", shell=True)
         self.bench_stop()
 
         logger.info("Decompression done")


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

With `shell=True`, a shell (e.g., /bin/sh -c) interprets `>` correctly as a redirection. Otherwise it's just another argument to the `gzip`/`gunzip` calls.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of compression, decompression, and cache-clearing operations by ensuring shell commands with output redirection work as expected within Docker containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->