### PR TITLE
chore(clp): Rename `user-guide` to `user-docs` and `dev-guide` to `dev-docs`, as per CLP docs PR

### DIFF
--- a/assets/clp/methodology.md
+++ b/assets/clp/methodology.md
@@ -8,7 +8,7 @@
 
 The benchmark builds on the public [**CLP core Ubuntu-Jammy**](http://ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-jammy) docker image.
 
-We use the clp-s binary, which is a variant of CLP optimized for semi-structured logs like JSON. We run clp-s with a target encoded size of 256MB, balancing compression ratio with search speed. Increasing the target encoded size can yield even better compression. Additional tuning options are documented in the user guide, [here.](https://docs.yscope.com/clp/v0.4.0/user-guide/core-clp-s)
+We use the clp-s binary, which is a variant of CLP optimized for semi-structured logs like JSON. We run clp-s with a target encoded size of 256MB, balancing compression ratio with search speed. Increasing the target encoded size can yield even better compression. Additional tuning options are documented in the user guide, [here.](https://docs.yscope.com/clp/v0.4.0/user-docs/core-clp-s)
 
 There is no need to launch clp-s, once built it can just be called on the command line and will be just shut down when it’s completed its command execution. The only thing we do before calling clp-s is to make a directory for its output files. We provide this as one of the parameters to the ingestion and search commands.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

[PR #1155](https://github.com/y-scope/clp/pull/1155) in `y-scope/clp` changes `user-guide` to `user-docs`. This PR modifies the single instance of `user-guide` in this repo to `user-docs` to comply.

Do not merge this PR until [PR #1155](https://github.com/y-scope/clp/pull/1155) is merged.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

N/A

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
